### PR TITLE
add init commit kubernetes-security

### DIFF
--- a/kubernetes-security/cd-sa.yaml
+++ b/kubernetes-security/cd-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cd
+  namespace: homework
+secrets:
+- name: cd-token
+  name: cd-token-expiring

--- a/kubernetes-security/clusterrole.yaml
+++ b/kubernetes-security/clusterrole.yaml
@@ -1,0 +1,7 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-api-reader
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/kubernetes-security/clusterrolebinding-admin.yaml
+++ b/kubernetes-security/clusterrolebinding-admin.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cd-admin
+  namespace: homework
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: cd
+  namespace: homework

--- a/kubernetes-security/clusterrolebinding.yaml
+++ b/kubernetes-security/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monitoring-metrics-api-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-api-reader
+subjects:
+- kind: ServiceAccount
+  name: monitoring
+  namespace: homework

--- a/kubernetes-security/cm.yaml
+++ b/kubernetes-security/cm.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-homework  # Название ConfigMap
+  namespace: homework       
+data:
+  # Произвольные пары ключ-значение в формате строк
+  APP_COLOR: "blue"
+  APP_MODE: "production"
+  LOG_LEVEL: "debug"
+  
+  # Многострочное значение (используется pipe "|")
+  CONFIG_JSON: |
+    {
+      "server": "api.example.com",
+      "port": 8080,
+      "timeout": 30
+    }
+
+  # Ключ с именем файла (значение будет аналогично файлу)
+  default.conf: |
+    server {
+      listen 8000;
+      server_name homework.otus;
+      root /homework;
+
+      # Обработка корня
+      location = / {
+          try_files /index.html =404;
+      }
+
+      location = /conf/file {
+        default_type text/plain;
+        add_header Content-Type text/plain;
+        try_files /config =404;
+      }
+
+      # Обработка index.html
+      location = /index.html {
+          try_files /index.html =404;
+      }
+
+      # Редирект homepage
+      location = /homepage {
+          return 301 /;
+      }
+
+      # Все остальные пути
+      location / {
+          return 404;
+      }
+
+      error_page 404 /404.html;
+      error_page 500 502 503 504 /50x.html;
+    }
+  config: |
+    myconfig data ....

--- a/kubernetes-security/cm.yaml
+++ b/kubernetes-security/cm.yaml
@@ -40,6 +40,10 @@ data:
           try_files /index.html =404;
       }
 
+      location = /metrics.html {
+          try_files /metrics/metrics.html =404;
+      }
+
       # Редирект homepage
       location = /homepage {
           return 301 /;

--- a/kubernetes-security/create_kubeconfig.sh
+++ b/kubernetes-security/create_kubeconfig.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.contexts[0].context.cluster}')
+APISERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+TOKEN=$(kubectl get secret cd-token -n homework -o jsonpath='{.data.token}' | base64 --decode)
+
+
+# Создаем временный файл конфигурации
+cat > kubeconfig-cd.yaml <<EOF
+apiVersion: v1
+kind: Config
+current-context: cd-context
+contexts:
+- name: cd-context
+  context:
+    cluster: ${CLUSTER_NAME}
+    namespace: homework
+    user: cd-user
+clusters:
+- name: ${CLUSTER_NAME}
+  cluster:
+    certificate-authority-data: $(kubectl config view --raw -o jsonpath="{.clusters[?(@.name=='${CLUSTER_NAME}')].cluster.certificate-authority-data}")
+    server: ${APISERVER}
+users:
+- name: cd-user
+  user:
+    token: ${TOKEN}
+EOF
+

--- a/kubernetes-security/deployment.yaml
+++ b/kubernetes-security/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: homework
+  name: kubernetes-networks
+  labels:
+    homework: kubernetes-networks
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  selector:
+    matchLabels:
+      homework: kubernetes-networks
+  template:
+    metadata:
+      labels:
+        homework: kubernetes-networks
+    spec:
+      nodeSelector:
+        homework: "true"
+      containers:
+      - name: web-server
+        image: nginx:1.27.2
+        ports:
+        - containerPort: 8000
+          name: http-web-svc
+        command: ["/bin/sh", "-c"]
+        args:
+          - "exec nginx -g 'daemon off;'"
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: default.conf
+        - name: webdir
+          mountPath: /homework
+        - name: homework-config
+          mountPath: /homework/config
+          subPath: config
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "rm -f /homework/index.html"]
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 2
+      initContainers:
+      - name: init
+        image: busybox:1.36
+        command: ["/bin/sh", "-c"]
+        args:
+          - "echo \"Homework 3. Hostname: $(hostname)\" > /init/index.html"
+        volumeMounts:
+        - name: webdir
+          mountPath: /init
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: configmap-homework
+      - name: homework-config
+        configMap:
+          name: configmap-homework
+      - name: webdir
+        persistentVolumeClaim:
+          claimName: pvc-homework  # Указываем имя существующего PVC
+      

--- a/kubernetes-security/deployment.yaml
+++ b/kubernetes-security/deployment.yaml
@@ -20,8 +20,10 @@ spec:
       labels:
         homework: kubernetes-networks
     spec:
+      serviceAccountName: monitoring
       nodeSelector:
         homework: "true"
+      automountServiceAccountToken: true  # Важно: разрешаем автоматическое монтирование токена
       containers:
       - name: web-server
         image: nginx:1.27.2
@@ -40,6 +42,8 @@ spec:
         - name: homework-config
           mountPath: /homework/config
           subPath: config
+        - name: shared-data
+          mountPath: /homework/metrics
         lifecycle:
           preStop:
             exec:
@@ -60,6 +64,21 @@ spec:
         volumeMounts:
         - name: webdir
           mountPath: /init
+      - name: fetch-metrics
+        image: curlimages/curl:8.6.0
+        command: ["/bin/sh", "-c"]
+        args: 
+          - |
+            curl -sS -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+            "https://kubernetes.default.svc/metrics" > /init/metrics.html
+            echo "API response saved to /init/metrics.html"
+        volumeMounts:
+        - name: shared-data
+          mountPath: /init
+        - name: default-token
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
       volumes:
       - name: nginx-config
         configMap:
@@ -69,5 +88,9 @@ spec:
           name: configmap-homework
       - name: webdir
         persistentVolumeClaim:
-          claimName: pvc-homework  # Указываем имя существующего PVC
-      
+          claimName: pvc-homework
+      - name: default-token  # Добавляем volume для токена
+        secret:
+          secretName: monitoring-token  # Имя секрета для вашего ServiceAccount
+      - name: shared-data
+        emptyDir: {}

--- a/kubernetes-security/ingress.yaml
+++ b/kubernetes-security/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homework-ingress
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /(homepage|index\.html|conf\/file|^/|$)
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: homework-service
+            port:
+              number: 80

--- a/kubernetes-security/ingress.yaml
+++ b/kubernetes-security/ingress.yaml
@@ -12,7 +12,7 @@ spec:
   - host: homework.otus
     http:
       paths:
-      - path: /(homepage|index\.html|conf\/file|^/|$)
+      - path: /(homepage|index\.html|metrics\.html|conf\/file|^/|$)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/kubernetes-security/monitoring-sa.yaml
+++ b/kubernetes-security/monitoring-sa.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: 
+    kubernetes.io/enforce-mountable-secrets: "true"
+  name: monitoring
+  namespace: homework
+secrets:
+- name: monitoring-token

--- a/kubernetes-security/namespace.yaml
+++ b/kubernetes-security/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-security/pvc.yaml
+++ b/kubernetes-security/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-homework  # Название PVC
+  namespace: homework
+spec:
+  accessModes:
+    - ReadWriteOnce  # Режим доступа (может быть ReadOnlyMany, ReadWriteMany)
+  resources:
+    requests:
+      storage: 1Gi  # Запрашиваемый объём (1 гигабайт)
+  storageClassName: rke-hostpath-retain

--- a/kubernetes-security/secret-cd-sa-expiration.yaml
+++ b/kubernetes-security/secret-cd-sa-expiration.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cd-token-expiring
+  namespace: homework
+  annotations:
+    kubernetes.io/service-account.name: cd
+    kubernetes.io/service-account.expiration: "86400"
+type: kubernetes.io/service-account-token
+ 

--- a/kubernetes-security/secret-cd-sa.yaml
+++ b/kubernetes-security/secret-cd-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cd-token
+  namespace: homework
+  annotations:
+    kubernetes.io/service-account.name: cd
+type: kubernetes.io/service-account-token

--- a/kubernetes-security/secret-sa.yaml
+++ b/kubernetes-security/secret-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: monitoring-token
+  namespace: homework
+  annotations:
+    kubernetes.io/service-account.name: monitoring
+type: kubernetes.io/service-account-token

--- a/kubernetes-security/service.yaml
+++ b/kubernetes-security/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: homework
+  name: homework-service
+spec:
+  selector:
+    homework: kubernetes-networks
+  ports:
+    - name: http-access-port
+      protocol: TCP
+      port: 80
+      targetPort: http-web-svc

--- a/kubernetes-security/storageclass.yaml
+++ b/kubernetes-security/storageclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rke-hostpath-retain
+  namespace: homework
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"  # Не делать default (можно изменить на "true")
+provisioner: driver.longhorn.io  # Используем рекомендуемый provisioner longhorn, так как у меня поднят кластер rke2
+reclaimPolicy: Retain  # Тома не удаляются автоматически после удаления PVC
+volumeBindingMode: Immediate  # Том создаётся сразу при создании PVC


### PR DESCRIPTION
# Выполнено ДЗ № 5

 - Основное ДЗ
 1. В namespace homework создать service account monitoring и дать ему доступ к эндпоинту /metrics вашего кластера
 1. Изменить манифест deployment из прошлых ДЗ так, чтобы поды запускались под service account monitoring
 1. В namespace homework создать service account с именем cd и дать ему роль admin в рамках namespace homework
 1. Создать kubeconfig для service account cd
 1. Сгенерировать для service account cd токен с временем действия 1 день и сохранить его в файл token
 - Задание со *
 1. Модифицировать deployment из прошлых ДЗ так, чтобы в процессе запуска pod происходило обращение к эндпоинту /metrics вашего кластера (механика вызова не принципиальна), результат ответа сохранялся в файл metrics.html и содержимое этого файла можно было бы получить при обращении по адресу /metrics.html вашего сервиса

## В процессе сделано:
 - Пункт 1
 - Пункт 2
 - Пункт 3
 - Пункт 4
 - Пункт 5
 - Пункт 6

## Замечания
 - Для выполнения пункта 1 нужно применить манифесты: monitoring-sa.yaml, secret-sa.yaml, clusterrole.yaml, clusterrolebinding.yaml.
  Должны появиться: сервис-аккаунт monitoring, секрет monitoring-token, ClusterRole metrics-api-reader, ClusterRoleBinding monitoring-metrics-api-reader
  Для того, чтобы извлечь токен
  ```bash
  kubectl get secret monitoring-token -n homework -o jsonpath='{.data.token}' | base64 --decode
  ```
  Для того, чтобы прочитать содержимое /metrics:
  ```bash
  curl -k -H "Authorization: Bearer <ваш-токен>" https://<API-сервер>/metrics
  ```
  Для определения адреса и порта API-сервера:
  ```bash
  kubectl cluster-info
  ```
  Или:
  ```bash
  kubectl config view --minify | grep server
  ```
 - Для выполнения пункта 2 нужно применить манифест deployment.yaml. Для проверки, что поды запустились под serviceAccount: monitoring, нужно выполнить:
  ```bash
  kubectl get pods -n homework -o yaml | grep serviceAccountName
  ```

 - Для выполнения пункта 3 нужно применить манифесты: cd-sa.yaml, secret-cd-sa-yaml, clusterrolebinding-admin.yaml
 - Для выполнения пункта 4 нужно запустить скрипт, который создает файл конфигурации kubeconfig - create_kubeconfig.sh. После чего можно применить конфигурацию для кластера:
  ```bash
  export KUBECONFIG=$(pwd)/kubeconfig-cd.yaml
  kubectl get pods -n homework
  ```
 - Для выполнения пункта 5:
  Применяем манифест secret-cd-sa-expiration.yaml, после чего сохраняем токен в файл:
  ```bash
  kubectl get secret cd-token-expiring -n homework -o jsonpath='{.data.token}' | base64 --decode > token 
  ```
  Затем можно проверить токен:
  ```bash
  APISERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
  curl -k -H "Authorization: Bearer $(cat token)" "$APISERVER/api/v1/namespaces/homework/pods"
  ```
- Задание со звездочкой выполнено, в deployment.yaml добавил init-контейнер с curl



